### PR TITLE
Fix version file syntax error and link

### DIFF
--- a/GameData/Pilot Assistant/PilotAssistant.version
+++ b/GameData/Pilot Assistant/PilotAssistant.version
@@ -1,1 +1,7 @@
-{"NAME":"Pilot Assistant","URL":"https://github.com/Crzyrndm/Pilot-Assistant/blob/master/GameData/Pilot%20Assistant/PilotAssistant.version","DOWNLOAD":"https://github.com/Crzyrndm/Pilot-Assistant/releases","VERSION":{"MAJOR":1,"MINOR":13,"PATCH":4},"KSP_VERSION":{"MAJOR":1,"MINOR":8,"PATCH":0}
+{
+    "NAME":        "Pilot Assistant",
+    "URL":         "https://github.com/zolotiyeruki/Pilot-Assistant/raw/master/GameData/Pilot%20Assistant/PilotAssistant.version",
+    "DOWNLOAD":    "https://github.com/zolotiyeruki/Pilot-Assistant/releases",
+    "VERSION":     {"MAJOR":1, "MINOR":13, "PATCH":4},
+    "KSP_VERSION": {"MAJOR":1, "MINOR":8}
+}


### PR DESCRIPTION
Currently this mod's version file has a syntax error that is blocking it from being indexed in CKAN (see KSP-CKAN/NetKAN#7459). Specifically, the closing `}` is missing at the end. This PR fixes that.

In addition, the `URL` and `DOWNLOAD` properties are updated to point to the new repo, which will allow KSP-AVC to notify users of available updates and allow the mod author to revise the game compatibility of the latest version without having to change the download. Finally, the `PATCH` property is removed from `KSP_VERSION` to indicate support for all 1.8.X game versions.

To get this listed on CKAN will require either a new release or updating the existing download with these fixes.